### PR TITLE
added an option to not index arrays using an flatten_array flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ The message is flattened like below:
 }
 ```
 
+In order to prevent arrays from being indexed, you can use a configuration like below:
+
+```
+<match message>
+  type flatten_hash
+  add_tag_prefix flattened.
+  separator _
+  flatten_array false
+</match>
+```
+
+Using the same input, you'll instead end up with a message flattened like below:
+
+```js
+{
+  "message_today":"good day",
+  "message_tommorow_is_a_bad":"day",
+  "days":["2013/08/24","2013/08/25"]
+}
+```
+
+
 ### Filter
 
 You can set a configuration like below:

--- a/lib/fluent/plugin/filter_flatten_hash.rb
+++ b/lib/fluent/plugin/filter_flatten_hash.rb
@@ -6,7 +6,8 @@ module Fluent
     include FlattenHashUtil
 
     config_param :separator, :string, :default => '.'
-
+    config_param :index_array, :bool, :default => true
+    
     def configure(conf)
       super
     end

--- a/lib/fluent/plugin/filter_flatten_hash.rb
+++ b/lib/fluent/plugin/filter_flatten_hash.rb
@@ -6,7 +6,7 @@ module Fluent
     include FlattenHashUtil
 
     config_param :separator, :string, :default => '.'
-    config_param :index_array, :bool, :default => true
+    config_param :flatten_array, :bool, :default => true
     
     def configure(conf)
       super

--- a/lib/fluent/plugin/flatten_hash_util.rb
+++ b/lib/fluent/plugin/flatten_hash_util.rb
@@ -7,9 +7,13 @@ module Fluent
           ret.merge! flatten_record(value, prefix + [key.to_s])
         }
       elsif record.is_a? Array
-        record.each_with_index { |elem, index|
-          ret.merge! flatten_record(elem, prefix + [index.to_s])
-        }
+        if @index_array
+          record.each_with_index { |elem, index|
+            ret.merge! flatten_record(elem, prefix + [index.to_s])
+          }
+        else
+          return {prefix.join(@separator) => record}
+        end
       else
         return {prefix.join(@separator) => record}
       end

--- a/lib/fluent/plugin/flatten_hash_util.rb
+++ b/lib/fluent/plugin/flatten_hash_util.rb
@@ -7,7 +7,7 @@ module Fluent
           ret.merge! flatten_record(value, prefix + [key.to_s])
         }
       elsif record.is_a? Array
-        if @index_array
+        if @flatten_array
           record.each_with_index { |elem, index|
             ret.merge! flatten_record(elem, prefix + [index.to_s])
           }

--- a/lib/fluent/plugin/out_flatten_hash.rb
+++ b/lib/fluent/plugin/out_flatten_hash.rb
@@ -8,6 +8,7 @@ module Fluent
 
     config_param :tag, :string, :default => nil
     config_param :separator, :string, :default => '.'
+    config_param :index_array, :bool, :default => true
 
     def initialize
       super

--- a/lib/fluent/plugin/out_flatten_hash.rb
+++ b/lib/fluent/plugin/out_flatten_hash.rb
@@ -8,7 +8,7 @@ module Fluent
 
     config_param :tag, :string, :default => nil
     config_param :separator, :string, :default => '.'
-    config_param :index_array, :bool, :default => true
+    config_param :flatten_array, :bool, :default => true
 
     def initialize
       super

--- a/test/plugin/test_filter_flatten_array.rb
+++ b/test/plugin/test_filter_flatten_array.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'fluent/plugin/filter_flatten_hash'
 
-class FlattenHashIndexArrayFilterTest < Test::Unit::TestCase
+class FlattenHashFlattenArrayFilterTest < Test::Unit::TestCase
   include Fluent
 
   BASE_CONFIG = %[
@@ -9,7 +9,7 @@ class FlattenHashIndexArrayFilterTest < Test::Unit::TestCase
   ]
   CONFIG = BASE_CONFIG + %[
     add_tag_prefix flattened
-    index_array false
+    flatten_array false
   ]
 
   def setup
@@ -21,7 +21,7 @@ class FlattenHashIndexArrayFilterTest < Test::Unit::TestCase
     Test::FilterTestDriver.new(FlattenHashFilter).configure(conf, true)
   end
 
-  def test_flatten_record_index_array_false
+  def test_flatten_record_flatten_array_false
     d = create_driver CONFIG
     es = Fluent::MultiEventStream.new
     now = Fluent::Engine.now

--- a/test/plugin/test_filter_index_array.rb
+++ b/test/plugin/test_filter_index_array.rb
@@ -1,0 +1,47 @@
+require 'helper'
+require 'fluent/plugin/filter_flatten_hash'
+
+class FlattenHashIndexArrayFilterTest < Test::Unit::TestCase
+  include Fluent
+
+  BASE_CONFIG = %[
+    type flatten_hash
+  ]
+  CONFIG = BASE_CONFIG + %[
+    add_tag_prefix flattened
+    index_array false
+  ]
+
+  def setup
+    Fluent::Test.setup
+    @time = Fluent::Engine.now
+  end
+
+  def create_driver(conf = '')
+    Test::FilterTestDriver.new(FlattenHashFilter).configure(conf, true)
+  end
+
+  def test_flatten_record_index_array_false
+    d = create_driver CONFIG
+    es = Fluent::MultiEventStream.new
+    now = Fluent::Engine.now
+
+    d.run do
+      d.emit({'message' => {'foo' => 'bar'}})
+      d.emit({"message" => {'foo' => 'bar', 'hoge' => 'fuga'}})
+      d.emit({"message" => {'nest' => {'foo' => 'bar'}}})
+      d.emit({"message" => {'nest' => {'nest' => {'foo' => 'bar'}}}})
+      d.emit({"message" => {'array' => ['foo', 'bar']}})
+      d.emit({"message" => {'array' => [{'foo' => 'bar'}, {'hoge' => 'fuga'}]}})
+    end
+
+    assert_equal [
+      {"message.foo" => "bar"},
+      {"message.foo" => "bar", "message.hoge" => "fuga"},
+      {"message.nest.foo" => "bar"},
+      {"message.nest.nest.foo" => "bar"},
+      {"message.array"=>["foo", "bar"]},
+      {"message.array"=>[{"foo"=>"bar"}, {"hoge"=>"fuga"}]},
+    ], d.filtered_as_array.map{|x| x[2]}
+  end
+end


### PR DESCRIPTION
By default, the index_array option is ignored, but when it's set to false, the original array is returned attached to the key normally created.  This might be a nice option for the hashes as well.  And some mods to the readme.md file would be valuable, but how does this look?