### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
+  - 2.3.1
 
 script:
   - bundle exec rake test

--- a/fluent-plugin-flatten-hash.gemspec
+++ b/fluent-plugin-flatten-hash.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", ["~> 0.12.0"]
+  spec.add_dependency "fluentd", [">= 0.14.8", "< 2"]
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
 end

--- a/lib/fluent/plugin/filter_flatten_hash.rb
+++ b/lib/fluent/plugin/filter_flatten_hash.rb
@@ -1,13 +1,15 @@
-module Fluent
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
   class FlattenHashFilter < Filter
-    Plugin.register_filter('flatten_hash', self)
+    Fluent::Plugin.register_filter('flatten_hash', self)
 
     require_relative 'flatten_hash_util'
-    include FlattenHashUtil
+    include Fluent::FlattenHashUtil
 
     config_param :separator, :string, :default => '.'
     config_param :flatten_array, :bool, :default => true
-    
+
     def configure(conf)
       super
     end
@@ -15,5 +17,5 @@ module Fluent
     def filter(tag, time, record)
       flatten_record(record, [])
     end
-  end if defined?(Filter)
+  end
 end

--- a/lib/fluent/plugin/out_flatten_hash.rb
+++ b/lib/fluent/plugin/out_flatten_hash.rb
@@ -1,10 +1,14 @@
-module Fluent
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
   class FlattenHashOutput < Output
     include Fluent::HandleTagNameMixin
     Fluent::Plugin.register_output('flatten_hash', self)
 
+    helpers :event_emitter
+
     require_relative 'flatten_hash_util'
-    include FlattenHashUtil
+    include Fluent::FlattenHashUtil
 
     config_param :tag, :string, :default => nil
     config_param :separator, :string, :default => '.'
@@ -21,11 +25,11 @@ module Fluent
           !remove_tag_suffix &&
           !add_tag_prefix &&
           !add_tag_suffix )
-        raise ConfigError, "out_flatten_hash: No tag parameters are set"
+        raise Fluent::ConfigError, "out_flatten_hash: No tag parameters are set"
       end
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       tag = @tag || tag
       es.each do |time, record|
         record = flatten_record(record, [])
@@ -33,7 +37,6 @@ module Fluent
         filter_record(t, time, record)
         router.emit(t, time, record)
       end
-      chain.next
     end
   end
 end

--- a/test/plugin/test_filter_flatten_hash.rb
+++ b/test/plugin/test_filter_flatten_hash.rb
@@ -1,8 +1,8 @@
 require 'helper'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/filter_flatten_hash'
 
 class FlattenHashFilterTest < Test::Unit::TestCase
-  include Fluent
 
   BASE_CONFIG = %[
     type flatten_hash
@@ -17,7 +17,7 @@ class FlattenHashFilterTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = '')
-    Test::FilterTestDriver.new(FlattenHashFilter).configure(conf, true)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::FlattenHashFilter).configure(conf, syntax: :v1)
   end
 
   def test_flatten_record
@@ -25,13 +25,13 @@ class FlattenHashFilterTest < Test::Unit::TestCase
     es = Fluent::MultiEventStream.new
     now = Fluent::Engine.now
 
-    d.run do
-      d.emit({'message' => {'foo' => 'bar'}})
-      d.emit({"message" => {'foo' => 'bar', 'hoge' => 'fuga'}})
-      d.emit({"message" => {'nest' => {'foo' => 'bar'}}})
-      d.emit({"message" => {'nest' => {'nest' => {'foo' => 'bar'}}}})
-      d.emit({"message" => {'array' => ['foo', 'bar']}})
-      d.emit({"message" => {'array' => [{'foo' => 'bar'}, {'hoge' => 'fuga'}]}})
+    d.run(default_tag: 'test') do
+      d.feed({'message' => {'foo' => 'bar'}})
+      d.feed({"message" => {'foo' => 'bar', 'hoge' => 'fuga'}})
+      d.feed({"message" => {'nest' => {'foo' => 'bar'}}})
+      d.feed({"message" => {'nest' => {'nest' => {'foo' => 'bar'}}}})
+      d.feed({"message" => {'array' => ['foo', 'bar']}})
+      d.feed({"message" => {'array' => [{'foo' => 'bar'}, {'hoge' => 'fuga'}]}})
     end
 
     assert_equal [
@@ -41,17 +41,17 @@ class FlattenHashFilterTest < Test::Unit::TestCase
       {"message.nest.nest.foo" => "bar"},
       {"message.array.0" => "foo", "message.array.1" => "bar"},
       {"message.array.0.foo" => "bar", "message.array.1.hoge" => "fuga"},
-    ], d.filtered_as_array.map{|x| x[2]}
+    ], d.filtered.map{|x| x[1]}
   end
 
   def test_separator
     d = create_driver CONFIG + %[separator /]
 
-    d.run do
-      d.emit({"message" => {'nest' => {'foo' => 'bar'}}})
+    d.run(default_tag: 'test') do
+      d.feed({"message" => {'nest' => {'foo' => 'bar'}}})
     end
     assert_equal [
       {"message/nest/foo" => "bar"},
-    ], d.filtered_as_array.map{|x| x[2]}
+    ], d.filtered.map{|x| x[1]}
   end
 end


### PR DESCRIPTION
Hi, I've tried to migrate using v0.14 API.
Could you consider to start using v0.14 API in this plugin?

Please refer to [the upgrading v0.12 to v0.14 guide](http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12) in more details.